### PR TITLE
Fix certificate signed by unknown authority

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
+FROM alpine:3.6 as certs
+
+RUN apk add -U --no-cache ca-certificates
+
+
 FROM scratch
 
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY bin/aws-asg-roller-linux-amd64 /aws-asg-roller
 
 CMD ["/aws-asg-roller"]


### PR DESCRIPTION
Fix this bug.
```
2019/04/29 03:21:36 Error adjusting AutoScaling Groups: Unexpected error describing ASGs, skipping: Unexpected and unknown AWS error when doing describe: RequestError: send request failed
caused by: Post https://autoscaling.us-east-2.amazonaws.com/: x509: certificate signed by unknown authority
```