### PR TITLE
Disable CGO Fix #3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,12 +41,12 @@ PACKAGE_NAME ?= github.com/$(IMAGE)
 IMGTAG = $(IMAGE):$(TAG)
 BINDIR ?= bin
 BINARY ?= $(BINDIR)/aws-asg-roller-$(OS)-$(ARCH)
-BUILD_CMD ?= GOOS=$(OS) GOARCH=$(ARCH) GO111MODULE=on
+BUILD_CMD ?= GOOS=$(OS) GOARCH=$(ARCH) GO111MODULE=on CGO_ENABLED=0
 
 ifdef DOCKERBUILD
 BUILDER ?= golang:1.12.4-alpine3.9
 BUILD_CMD = docker run --rm \
-    -e GOOS=$(OS) -e GOARCH=$(ARCH) -e GO111MODULE=on \
+    -e GOOS=$(OS) -e GOARCH=$(ARCH) -e GO111MODULE=on -e CGO_ENABLED=0 \
 		-e GOCACHE=/gocache \
 		-v $(CURDIR)/.gocache:/gocache \
 		-v $(CURDIR):/go/src/$(PACKAGE_NAME) \


### PR DESCRIPTION
The latest image is broken.

```
$ docker run -it --rm deitch/aws-asg-roller:f094762050f6da1ae6021b5b7aa7f5abc668a953-dirty
standard_init_linux.go:207: exec user process caused "no such file or directory"
```

I'm not familiar with golang, I searched for this error. It seems that disable CGO can solve this problem. 

I copied the `/aws-asg-roller` in the image to `ubuntu` and it works ok. This makes me more certain that this problem is caused by CGO

```
FROM deitch/aws-asg-roller:f094762050f6da1ae6021b5b7aa7f5abc668a953-dirty as base

FROM ubuntu

COPY --from=base /aws-asg-roller /aws-asg-roller

CMD ["/aws-asg-roller"]
```

Ref: https://stackoverflow.com/questions/45722785/what-docker-scratch-contains-by-default/45722910