### PR TITLE
fix: case where asg instances dont have a launch config set

### DIFF
--- a/roller.go
+++ b/roller.go
@@ -176,7 +176,7 @@ func groupInstances(asg *autoscaling.Group) ([]*autoscaling.Instance, []*autosca
 	targetLc := asg.LaunchConfigurationName
 	// go through each instance and find those that are not with the target LC
 	for _, i := range asg.Instances {
-		if *i.LaunchConfigurationName == *targetLc {
+		if i.LaunchConfigurationName != nil && *i.LaunchConfigurationName == *targetLc {
 			newInstances = append(newInstances, i)
 		} else {
 			oldInstances = append(oldInstances, i)


### PR DESCRIPTION
Found this case in our aws environment. I'm not sure exactly how you get
instances in an ASG without a launch config set. Possibly the launch
config was deleted or existing instances were somehow added to the asg
and not launched by the asg ( I didn't set these up, just inherited them
:D )