### PR TITLE
Fix panic by treat instances without configuration name as old instan…

### DIFF
--- a/roller.go
+++ b/roller.go
@@ -176,7 +176,8 @@ func groupInstances(asg *autoscaling.Group) ([]*autoscaling.Instance, []*autosca
 	targetLc := asg.LaunchConfigurationName
 	// go through each instance and find those that are not with the target LC
 	for _, i := range asg.Instances {
-		if *i.LaunchConfigurationName == *targetLc {
+		// If instances' LaunchConfiguration has been deleted, treat them as old instances.
+		if i.LaunchConfigurationName != nil &&  *i.LaunchConfigurationName == *targetLc {
 			newInstances = append(newInstances, i)
 		} else {
 			oldInstances = append(oldInstances, i)


### PR DESCRIPTION
I am using Terraform to manage ASG. If there are any changes, it will delete the old Launch Configuration and create a new one, so the old instances' LaunchConfigurationName will be nil.

Error logs:
```
2019/04/30 02:03:22 Sleeping 30 seconds
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x1227faf]

goroutine 1 [running]:
main.groupInstances(0xc0003e88c0, 0xc0000f1620, 0xc000043b00, 0x2c, 0xc0000f18e8, 0xc00000e4d8, 0x1)
	/home/travis/gopath/src/github.com/deitch/aws-asg-roller/roller.go:179 +0xef
main.adjust(0xc0003ac310, 0x1, 0x1, 0x1839260, 0xc00000e6c8, 0x1830a20, 0xc00000e6b8, 0x17ccbe0, 0xc0003ad700, 0xc0000f1e88, ...)
	/home/travis/gopath/src/github.com/deitch/aws-asg-roller/roller.go:29 +0x27e
main.main()
	/home/travis/gopath/src/github.com/deitch/aws-asg-roller/main.go:42 +0x39c
```

The output of `aws autoscaling describe-auto-scaling-instances`

```
$ aws autoscaling describe-auto-scaling-instances
{
    "AutoScalingInstances": [
        {
            "InstanceId": "i-XXXXX",
            "AutoScalingGroupName": "AutoScalingGroupName",
            "AvailabilityZone": "us-east-2a",
            "LifecycleState": "InService",
            "HealthStatus": "HEALTHY",
            "ProtectedFromScaleIn": false
        },
        {
            "InstanceId": "i-XXXXX",
            "AutoScalingGroupName": "AutoScalingGroupName",
            "AvailabilityZone": "us-east-2a",
            "LifecycleState": "InService",
            "HealthStatus": "HEALTHY",
            "ProtectedFromScaleIn": false
        },
        {
            "InstanceId": "i-XXXXX",
            "AutoScalingGroupName": "AutoScalingGroupName",
            "AvailabilityZone": "us-east-2a",
            "LifecycleState": "InService",
            "HealthStatus": "HEALTHY",
            "LaunchConfigurationName": "AutoScalingGroupName20190429091314512400000001",
            "ProtectedFromScaleIn": false
        }
    ]
}
```