### PR TITLE
make delay configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ ASG Roller takes its configuration via environment variables. All environment va
 * `ROLLER_ASG`: comma-separated list of auto-scaling groups that should be managed.
 * `ROLLER_KUBERNETES`: If set to `true`, will check if a new node is ready via-a-vis Kubernetes before declaring it "ready", and will drain an old node before eliminating it. Defaults to `true` when running in Kubernetes as a pod, `false` otherwise.
 * `ROLLER_IGNORE_DAEMONSETS`: If set to `false`, will not reclaim a node until there are no DaemonSets running on the node; if set to `true` (default), will reclaim node when all regular pods are drained off, but will ignore the presence of DaemonSets, which should be present on every node anyways. Normally, you want this set to `true`, which is the default.
+* `ROLLER_CHECK_DELAY`: Time, in seconds, between checks of ASG status.
 * `KUBECONFIG`: Path to kubernetes config file for authenticating to the kubernetes cluster. Required only if `ROLLER_KUBERNETES` is `true` and we are not operating in a kubernetes cluster.
 
 ## Building

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGetDelay(t *testing.T) {
+	tests := []struct {
+		name        string
+		want        int
+		envValue    string
+		shouldError bool
+	}{
+		{"should return default", 30, "", false},
+		{"should return override", 17, "17", false},
+		{"should error if override invalid", 0, "fake", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Unsetenv("ROLLER_CHECK_DELAY")
+
+			if tt.envValue != "" {
+				os.Setenv("ROLLER_CHECK_DELAY", tt.envValue)
+			}
+
+			got, err := getDelay()
+			if err != nil {
+				if !tt.shouldError {
+					t.Errorf("getDelay() returned error: %s", err.Error())
+				}
+			} else {
+				if tt.shouldError {
+					t.Error("getDelay() should have returned error")
+				} else if got != tt.want {
+					t.Errorf("getDelay() = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Allow check delay to be configurable. 
30 seconds might be too short or too long for some users. 