### PR TITLE
move delay to after action in loop

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,13 +43,13 @@ func main() {
 
 	// infinite loop
 	for {
-		// delay with each loop
-		log.Printf("Sleeping %d seconds\n", checkDelay)
-		time.Sleep(time.Duration(checkDelay) * time.Second)
 		err = adjust(asgList, ec2Svc, asgSvc, readinessHandler, originalDesired)
 		if err != nil {
 			log.Printf("Error adjusting AutoScaling Groups: %v", err)
 		}
+		// delay with each loop
+		log.Printf("Sleeping %d seconds\n", checkDelay)
+		time.Sleep(time.Duration(checkDelay) * time.Second)
 	}
 }
 


### PR DESCRIPTION
Not sure if the delay was intentionally added to the start of the loop.
This PR moves the delay to after the loop so we don't have to wait for the delay time to see if we have configured this properly on the first run. 