### PR TITLE
Add deleteLocalData flag, basic logging, and cluster-autoscaler annotation

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker build --build-arg OS=linux  --build-arg ARCH=amd64 -f $DOCKERFILE_PATH -t $IMAGE_NAME .

--- a/hooks/build
+++ b/hooks/build
@@ -1,2 +1,0 @@
-#!/bin/bash
-docker build --build-arg OS=linux  --build-arg ARCH=amd64 -f $DOCKERFILE_PATH -t $IMAGE_NAME .

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-const clusterAutoscalerScaleDownDisabledFlag := "cluster-autoscaler.kubernetes.io/scale-down-disabled"
+const clusterAutoscalerScaleDownDisabledFlag = "cluster-autoscaler.kubernetes.io/scale-down-disabled"
 
 type kubernetesReadiness struct {
 	clientset        *kubernetes.Clientset

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -14,6 +14,8 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+const clusterAutoscalerScaleDownDisabledFlag := "cluster-autoscaler.kubernetes.io/scale-down-disabled"
+
 type kubernetesReadiness struct {
 	clientset        *kubernetes.Clientset
 	ignoreDaemonSets bool
@@ -149,7 +151,7 @@ func setScaleDownDisabledAnnotation(hostnames []string) ([]string, error) {
 		node      *corev1.Node
 		hostname  string
 		err       error
-		key       = "cluster-autoscaler.kubernetes.io/scale-down-disabled"
+		key       = clusterAutoscalerScaleDownDisabledFlag
 		annotated = []string{}
 	)
 	clientset, err := kubeGetClientset()
@@ -181,7 +183,7 @@ func removeScaleDownDisabledAnnotation(hostnames []string) error {
 		node     *corev1.Node
 		hostname string
 		err      error
-		key      = "cluster-autoscaler.kubernetes.io/scale-down-disabled"
+		key      = clusterAutoscalerScaleDownDisabledFlag
 	)
 	clientset, err := kubeGetClientset()
 	if err != nil {

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -171,7 +171,10 @@ func setScaleDownDisabledAnnotation(hostnames []string) ([]string, error) {
 		if value := annotations[key]; value != "true" {
 			annotations[key] = "true"
 			node.SetAnnotations(annotations)
-			nodes.Update(node)
+			_, err := nodes.Update(node)
+			if err != nil {
+				return annotated, err
+			}
 			annotated = append(annotated, h)
 		}
 	}
@@ -202,7 +205,10 @@ func removeScaleDownDisabledAnnotation(hostnames []string) error {
 		if _, ok := annotations[key]; ok {
 			delete(annotations, key)
 			node.SetAnnotations(annotations)
-			nodes.Update(node)
+			_, err := nodes.Update(node)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ func main() {
 
 	// get config env
 	ignoreDaemonSets := os.Getenv("ROLLER_IGNORE_DAEMONSETS") != "false"
-	deleteLocalData := os.Getenv("ROLLER_DELETE_LOCAL_DATA") != "false"
+	deleteLocalData := strings.ToLower(os.Getenv("ROLLER_DELETE_LOCAL_DATA")) == "true"
 	// get a kube connection
 	readinessHandler, err := kubeGetReadinessHandler(ignoreDaemonSets, deleteLocalData)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -21,8 +21,9 @@ func main() {
 
 	// get config env
 	ignoreDaemonSets := os.Getenv("ROLLER_IGNORE_DAEMONSETS") != "false"
+	deleteLocalData := os.Getenv("ROLLER_DELETE_LOCAL_DATA") != "false"
 	// get a kube connection
-	readinessHandler, err := kubeGetReadinessHandler(ignoreDaemonSets)
+	readinessHandler, err := kubeGetReadinessHandler(ignoreDaemonSets, deleteLocalData)
 	if err != nil {
 		log.Fatalf("Error getting kubernetes readiness handler when required: %v", err)
 	}
@@ -43,7 +44,7 @@ func main() {
 
 	// infinite loop
 	for {
-		err = adjust(asgList, ec2Svc, asgSvc, readinessHandler, originalDesired)
+		err := adjust(asgList, ec2Svc, asgSvc, readinessHandler, originalDesired)
 		if err != nil {
 			log.Printf("Error adjusting AutoScaling Groups: %v", err)
 		}

--- a/roller.go
+++ b/roller.go
@@ -194,7 +194,8 @@ func calculateAdjustment(asg *autoscaling.Group, ec2Svc ec2iface.EC2API, hostnam
 			return desired, originalDesired, "", fmt.Errorf("Error getting readiness new node status: %v", err)
 		}
 		if unReadyCount > 0 {
-			return desired, originalDesired, "", fmt.Errorf("[%s] Nodes not ready: %d", *asg.AutoScalingGroupName, unReadyCount)
+			log.Printf("[%s] Nodes not ready: %d", *asg.AutoScalingGroupName, unReadyCount)
+			return desired, originalDesired, "", nil
 		}
 	}
 	candidate := *oldInstances[0].InstanceId

--- a/roller.go
+++ b/roller.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
@@ -31,12 +32,20 @@ func adjust(asgList []string, ec2Svc ec2iface.EC2API, asgSvc autoscalingiface.Au
 		}
 		// if there are no outdated instances skip updating
 		if len(oldI) == 0 {
+			log.Printf("[%s] ok\n", *asg.AutoScalingGroupName)
+			err := ensureNoScaleDownDisabledAnnotation(ec2Svc, mapInstancesIds(asg.Instances))
+			if err != nil {
+				log.Printf("[%s] Unable to update node annotations: %v\n", *asg.AutoScalingGroupName, err)
+			}
 			continue
 		}
+
+		log.Printf("[%s] need updates: %d\n", *asg.AutoScalingGroupName, len(oldI))
 
 		asgMap[*asg.AutoScalingGroupName] = asg
 		instances = append(instances, oldI...)
 		instances = append(instances, newI...)
+
 	}
 	// no instances no work needed
 	if len(instances) == 0 {
@@ -59,9 +68,14 @@ func adjust(asgList []string, ec2Svc ec2iface.EC2API, asgSvc autoscalingiface.Au
 	// keep keyed references to the ASGs
 	for _, asg := range asgMap {
 		newDesiredA, newOriginalA, terminateID, err := calculateAdjustment(asg, ec2Svc, hostnameMap, readinessHandler, originalDesired[*asg.AutoScalingGroupName])
+		log.Printf("[%s] desired: %d original: %d", *asg.AutoScalingGroupName, newDesiredA, newOriginalA)
+		if err != nil {
+			log.Printf("[%s] error: %v\n", *asg.AutoScalingGroupName, err)
+		}
 		newDesired[*asg.AutoScalingGroupName] = newDesiredA
 		newOriginalDesired[*asg.AutoScalingGroupName] = newOriginalA
 		if terminateID != "" {
+			log.Printf("[%s] Scheduled termination: %s", *asg.AutoScalingGroupName, terminateID)
 			newTerminate[*asg.AutoScalingGroupName] = terminateID
 		}
 		errors[asg.AutoScalingGroupName] = err
@@ -72,6 +86,7 @@ func adjust(asgList []string, ec2Svc ec2iface.EC2API, asgSvc autoscalingiface.Au
 	}
 	// adjust current desired
 	for asg, desired := range newDesired {
+		log.Printf("[%s] set desired instances: %d\n", asg, desired)
 		err = setAsgDesired(asgSvc, asgMap[asg], desired)
 		if err != nil {
 			return fmt.Errorf("Error setting desired to %d for ASG %s: %v", desired, asg, err)
@@ -79,6 +94,7 @@ func adjust(asgList []string, ec2Svc ec2iface.EC2API, asgSvc autoscalingiface.Au
 	}
 	// terminate nodes
 	for asg, id := range newTerminate {
+		log.Printf("[%s] terminating node: %s\n", asg, id)
 		// all new config instances are ready, terminate an old one
 		err = awsTerminateNode(asgSvc, id)
 		if err != nil {
@@ -86,6 +102,16 @@ func adjust(asgList []string, ec2Svc ec2iface.EC2API, asgSvc autoscalingiface.Au
 		}
 	}
 	return nil
+}
+
+// ensureNoScaleDownDisabledAnnotation remove any "cluster-autoscaler.kubernetes.io/scale-down-disabled"
+// annotations in the nodes as no update is required anymore.
+func ensureNoScaleDownDisabledAnnotation(ec2Svc ec2iface.EC2API, ids []string) error {
+	hostnames, err := awsGetHostnames(ec2Svc, ids)
+	if err != nil {
+		return fmt.Errorf("Unable to get aws hostnames for ids %v: %v", ids, err)
+	}
+	return removeScaleDownDisabledAnnotation(hostnames)
 }
 
 // calculateAdjustment calculates the new settings for the desired number, and which node (if any) to terminate
@@ -131,6 +157,7 @@ func calculateAdjustment(asg *autoscaling.Group, ec2Svc ec2iface.EC2API, hostnam
 		if *i.HealthStatus == healthy {
 			readyCount++
 		}
+
 	}
 	if int64(readyCount) < originalDesired+1 {
 		return desired, originalDesired, "", nil
@@ -158,12 +185,16 @@ func calculateAdjustment(asg *autoscaling.Group, ec2Svc ec2iface.EC2API, hostnam
 		for _, i := range ids {
 			hostnames = append(hostnames, hostnameMap[i])
 		}
+		_, err = setScaleDownDisabledAnnotation(hostnames)
+		if err != nil {
+			log.Printf("Unable to set disabled scale down annotations: %v", err)
+		}
 		unReadyCount, err = readinessHandler.getUnreadyCount(hostnames, ids)
 		if err != nil {
 			return desired, originalDesired, "", fmt.Errorf("Error getting readiness new node status: %v", err)
 		}
 		if unReadyCount > 0 {
-			return desired, originalDesired, "", nil
+			return desired, originalDesired, "", fmt.Errorf("[%s] Nodes not ready: %d", *asg.AutoScalingGroupName, unReadyCount)
 		}
 	}
 	candidate := *oldInstances[0].InstanceId

--- a/roller_internal_test.go
+++ b/roller_internal_test.go
@@ -134,6 +134,7 @@ func TestCalculateAdjustment(t *testing.T) {
 			DesiredCapacity:         &tt.desired,
 			LaunchConfigurationName: &lcName,
 			Instances:               instances,
+			AutoScalingGroupName:    aws.String("myasg"),
 		}
 		ec2Svc := &mockEc2Svc{
 			autodescribe: true,


### PR DESCRIPTION
Quick workaround for #19 #21.

Originally, wanted to refine the fix abit (use proper logging, better handle the node annotation, etc), but I just couldn't find the time, so here is the PR - not ideal, but it is working in my cluster.

## Changes
- add `deleteLocalData` flag for node draining because some of my pods uses the local data volume mount
- add some really basic logging because I needed them to debug and monitor aws-asg-roller state
- add basic func to set node annotation in k8s to prevent cluster-autoscaler to scale down the nodes, and removing the annotations when update is done

## Important Note
summary of how annotation is handled:
- if asg needs update, annotate all old nodes with flag to prevent scaling down
- if asg does not need update, remove flag from all nodes in asg

> Hence if aws-asg-roller is improperly killed or removed without restart or redeployment, the old instances will be annotated with the no scale down flag!