### PR TITLE
Add check for nil target launch configuration

### DIFF
--- a/roller.go
+++ b/roller.go
@@ -288,7 +288,7 @@ func groupInstances(asg *autoscaling.Group, ec2Svc ec2iface.EC2API) ([]*autoscal
 				newInstances = append(newInstances, i)
 			}
 		}
-	} else {
+	} else if targetLc != nil {
 		// go through each instance and find those that are not with the target LC
 		for _, i := range asg.Instances {
 			if i.LaunchConfigurationName != nil && *i.LaunchConfigurationName == *targetLc {
@@ -300,6 +300,8 @@ func groupInstances(asg *autoscaling.Group, ec2Svc ec2iface.EC2API) ([]*autoscal
 				oldInstances = append(oldInstances, i)
 			}
 		}
+	} else {
+		return nil, nil, fmt.Errorf("both target launch configuration and launch template are nil")
 	}
 	return oldInstances, newInstances, nil
 }


### PR DESCRIPTION
Follow up to #30 

So interestingly enough, I got the following issue after #30:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x12d338f]

goroutine 1 [running]:
main.groupInstances(0xc0007a7760, 0x1982a40, 0xc00000e6c8, 0x2, 0x2, 0x0, 0x0, 0x2, 0x2, 0x0, ...)
        /go/src/github.com/deitch/aws-asg-roller/roller.go:298 +0x2ff
main.adjust(0xc000418000, 0xf, 0xf, 0x1982a40, 0xc00000e6c8, 0x1979e60, 0xc00000e6b8, 0x1914f00, 0xc000413960, 0xc000935e88, ...)
        /go/src/github.com/deitch/aws-asg-roller/roller.go:28 +0x269
main.main()
        /go/src/github.com/deitch/aws-asg-roller/main.go:51 +0x3e7
&{0xc0000b4280}
```

This appears to be targeted specifically at an ASG with multiple instance types.

Anyways, this PR is relevant either way; it's not because the target LT is nil that the LC is automatically not nil.

