### PR TITLE
Support mixed instance policies.

### DIFF
--- a/roller.go
+++ b/roller.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
-	"log"
 )
 
 const (
@@ -225,6 +226,9 @@ func groupInstances(asg *autoscaling.Group, ec2Svc ec2iface.EC2API) ([]*autoscal
 	// we want to be able to handle LaunchTemplate as well
 	targetLc := asg.LaunchConfigurationName
 	targetLt := asg.LaunchTemplate
+	if targetLt == nil && asg.MixedInstancesPolicy != nil && asg.MixedInstancesPolicy.LaunchTemplate != nil {
+		targetLt = asg.MixedInstancesPolicy.LaunchTemplate.LaunchTemplateSpecification
+	}
 	// prioritize LaunchTemplate over LaunchConfiguration
 	if targetLt != nil {
 		// we are using LaunchTemplate. Unlike LaunchConfiguration, you can have two nodes in the ASG

--- a/roller_internal_test.go
+++ b/roller_internal_test.go
@@ -399,6 +399,39 @@ func TestGroupInstances(t *testing.T) {
 			runTest(t, asg, i, tt.oldIds, tt.newIds)
 		}
 	})
+	t.Run("launchtemplatemixedinstances", func(t *testing.T) {
+		for i, tt := range tests {
+			instances := make([]*autoscaling.Instance, 0)
+			ltName := "lt1"
+			ltNameNew := ltName
+			ltNameOld := fmt.Sprintf("old-%s", ltName)
+			for _, instance := range tt.oldIds {
+				id := instance
+				instances = append(instances, &autoscaling.Instance{
+					InstanceId:     &id,
+					LaunchTemplate: &autoscaling.LaunchTemplateSpecification{LaunchTemplateName: &ltNameOld},
+				})
+			}
+			for _, instance := range tt.newIds {
+				id := instance
+				instances = append(instances, &autoscaling.Instance{
+					InstanceId:     &id,
+					LaunchTemplate: &autoscaling.LaunchTemplateSpecification{LaunchTemplateName: &ltNameNew},
+				})
+			}
+			// construct the Group we will pass
+			asg := &autoscaling.Group{
+				MixedInstancesPolicy: &autoscaling.MixedInstancesPolicy{
+					LaunchTemplate: &autoscaling.LaunchTemplate{
+						LaunchTemplateSpecification: &autoscaling.LaunchTemplateSpecification{LaunchTemplateName: &ltName},
+					},
+				},
+				Instances: instances,
+			}
+			runTest(t, asg, i, tt.oldIds, tt.newIds)
+		}
+	})
+
 }
 
 func TestMapInstanceIds(t *testing.T) {


### PR DESCRIPTION
When a mixed instance policy is enabled for an autoscaling group, the
launch template value is under the mixed instances policy part of the
returned object.