### PR TITLE
Adds verbose logging for MixedInstancesPolicy

### DIFF
--- a/roller.go
+++ b/roller.go
@@ -226,7 +226,11 @@ func groupInstances(asg *autoscaling.Group, ec2Svc ec2iface.EC2API) ([]*autoscal
 	// we want to be able to handle LaunchTemplate as well
 	targetLc := asg.LaunchConfigurationName
 	targetLt := asg.LaunchTemplate
+	// check for mixed instance policy
 	if targetLt == nil && asg.MixedInstancesPolicy != nil && asg.MixedInstancesPolicy.LaunchTemplate != nil {
+		if verbose {
+			log.Printf("[%s] using mixed instances policy launch template", *asg.AutoScalingGroupName)
+		}
 		targetLt = asg.MixedInstancesPolicy.LaunchTemplate.LaunchTemplateSpecification
 	}
 	// prioritize LaunchTemplate over LaunchConfiguration


### PR DESCRIPTION
This adds verbose logging when using Mixed Instances Policy.

### Logs

The additional (verbose only) log entry looks like this:
```
2020/03/27 11:16:52 [my_asg_name] using mixed instances policy launch template
```

**Note:** This PR originally added support as well as the verbose logging. The support itself was merged [a few hours ago](https://github.com/deitch/aws-asg-roller/pull/33), so this just adds the logging!

---

## Original PR follows

This adds support for Auto Scaling Groups using a Mixed Instances Policy.

In this case, where more than one instance type is permitted for the ASG, the launch template is `nil` and the roller fails with:

```
both target launch configuration and launch template are nil
```

> Please see https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_MixedInstancesPolicy.html for background information.

### Logs

The additional (verbose only) log entry looks like this:
```
2020/03/27 11:16:52 [my_asg_name] using mixed instances policy launch template
```