### PR TITLE
Adds support to increase ASG max to accommodate desired count

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ ASG Roller takes its configuration via environment variables. All environment va
 * `ROLLER_IGNORE_DAEMONSETS`: If set to `false`, will not reclaim a node until there are no DaemonSets running on the node; if set to `true` (default), will reclaim node when all regular pods are drained off, but will ignore the presence of DaemonSets, which should be present on every node anyways. Normally, you want this set to `true`, which is the default.
 * `ROLLER_DELETE_LOCAL_DATA`: If set to `false` (default), will not reclaim a node until there are no pods with [emptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) running on the node; if set to `true`, will continue to terminate the pod and delete the local data before reclaiming the node. The default is `false` to maintain backward compatibility. 
 * `ROLLER_CHECK_DELAY`: Time, in seconds, between checks of ASG status.
+* `ROLLER_CAN_INCREASE_MAX`: If set to `true`, will increase the ASG maximum size to accommodate the increase in desired count. If set to `false`, will instead error when desired is higher than max.
 * `ROLLER_VERBOSE`: If set to `true`, will increase verbosity of logs.
 * `KUBECONFIG`: Path to kubernetes config file for authenticating to the kubernetes cluster. Required only if `ROLLER_KUBERNETES` is `true` and we are not operating in a kubernetes cluster.
 

--- a/main.go
+++ b/main.go
@@ -14,7 +14,8 @@ const (
 )
 
 var (
-	verbose = os.Getenv("ROLLER_VERBOSE") == "true"
+	verbose        = os.Getenv("ROLLER_VERBOSE") == "true"
+	canIncreaseMax = os.Getenv("ROLLER_CAN_INCREASE_MAX") == "true"
 )
 
 func main() {


### PR DESCRIPTION
This adds support to increase ASG max to accommodate desired count.

Currently the README implies that the roller will:

> Modify the min, max and desired parameters of an ASG

However, in the case where the _desired_ is higher than the _max_, the roller will fail.

This PR adds an explicit log and fail case, as well as adding an new behaviour to raise the ASG max, if the `ROLLER_CAN_INCREASE_MAX` environment variable is set to `true`.

Coverage is improved to include tests for successful and failed changes to the max value, as well as an additional test for when updates are complete.

## Logs

The new (verbose only) logs for changing the max look like this:

```
increasing ASG my_asg_name max size to 3 to accommodate desired count
...
increased ASG my_asg_name max size to 3 to accommodate desired count
```

If the option is disabled, then the following explicit error is logged:

```
unable to increase ASG my_asg_name desired size to 3 as greater than max size 2
```