### PR TITLE
Verbose logs printing pointers instead of value

### DIFF
--- a/util.go
+++ b/util.go
@@ -1,0 +1,22 @@
+package main
+
+// p2v is the equivalent of referencing a pointer, but safely (no panic).
+// Should be used for printing purposes (i.e. fmt.Printf(...))
+func p2v(p interface{}) interface{} {
+	switch value := p.(type) {
+	case *string:
+		if value == nil {
+			return "<nil>"
+		} else {
+			return *value
+		}
+	case *int64:
+		if value == nil {
+			return "<nil>"
+		} else {
+			return *value
+		}
+	default:
+		return value
+	}
+}

--- a/util.go
+++ b/util.go
@@ -7,15 +7,13 @@ func p2v(p interface{}) interface{} {
 	case *string:
 		if value == nil {
 			return "<nil>"
-		} else {
-			return *value
 		}
+		return *value
 	case *int64:
 		if value == nil {
 			return "<nil>"
-		} else {
-			return *value
 		}
+		return *value
 	default:
 		return value
 	}


### PR DESCRIPTION
Fixes #40 

So it turns out that while #39 did fix the issue with pointers (no more panics!), the default value of a string's pointer is another pointer, (to the slice of chars), and well, verbose logs are useless if you can't see the actual values.

The dilemma is that if somebody has verbose logs enabled, they're probably running into an issue -- meaning that they want to see the values. However, if they are having an issue, it's likely that there's an issue with the values themselves, which would cause a panic if a nil value is dereferenced. 

My solution to that was to create a function that "safely" dereferences the value by checking if its pointer is nil before converting it.

I think this definitely beats having to do multiple ifs for each verbose logs in term of readability, and I've also opted to name the function `p2v`, short for `pointer to string`, in order to minimize the impact of readability.

Before:

```golang
log.Printf("[%v] returning desired to original value %d", *asg.AutoScalingGroupName, originalDesired)
```

After:
```golang
log.Printf("[%v] returning desired to original value %d", p2v(asg.AutoScalingGroupName), originalDesired)
```


The `p2v` only explicitly supports string and int64 pointers, because these are the two only values used by aws' sdk that we use for aws-asg-roller.


Let me know what you think, I'm open to suggestions, but I do think this might be the most foolproof way of doing it.

FYI, running the tests with the `ROLLER_VERBOSE` environment variable confirms that this indeed works as expected.